### PR TITLE
feat: add support for custom random state

### DIFF
--- a/bounded-static/Cargo.toml
+++ b/bounded-static/Cargo.toml
@@ -21,7 +21,7 @@ alloc = []
 collections = [ "alloc" ]
 
 # Enable impls of [To|Into]BoundedStatic for other types in std.
-std = [ "alloc" ]
+std = [ "alloc", "ahash?/std" ]
 
 # Enable the ToStatic custom derive macro.
 derive = [ "bounded-static-derive" ]
@@ -31,6 +31,7 @@ bounded-static-derive = { version = "0.5.0", path = "../bounded-static-derive", 
 smol_str = { version = "0.2.0", optional = true, default_features = false }
 smallvec = { version = "1.8.0", optional = true, default_features = false }
 smartstring = { version = "1.0.0", optional = true, default_features = false }
+ahash = { version = "0.8.3", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
`HashMap` and `HashSet` with custom random states such as [`ahash::HashMap`](https://docs.rs/ahash/latest/ahash/type.HashMap.html) and [`ahash::HashSet`](https://docs.rs/ahash/latest/ahash/type.HashSet.html) will be supported in this PR.

Note that this is a breaking change, as the type of return value is changed from `std::collections::HashMap<_, _, std::collections::hash_map::RandomState>` to `std::collections::HashMap<_, _, S>`.